### PR TITLE
fixing web cloner - fallback option with urllib

### DIFF
--- a/src/webattack/web_clone/cloner.py
+++ b/src/webattack/web_clone/cloner.py
@@ -171,7 +171,7 @@ try:
                     # open file for writing
                     filewrite = open(userconfigpath + "web_clone/index.html", "w")
                     # write the data back from the request
-                    filewrite.write(html)
+                    filewrite.write(html.decode("utf-8"))
                     # close the file
                     filewrite.close()
 


### PR DESCRIPTION
This is a fix for this issue [https://github.com/trustedsec/social-engineer-toolkit/issues/307](https://github.com/trustedsec/social-engineer-toolkit/issues/307)